### PR TITLE
implement rotations in balancedTree

### DIFF
--- a/src/main/kotlin/AVL/AVLTree.kt
+++ b/src/main/kotlin/AVL/AVLTree.kt
@@ -31,18 +31,17 @@ class AVLTree<K : Comparable<K>, V>: balancedTree<K, V, AVLNode<K, V>>() {
     private fun getBalanceFactor(node: AVLNode<K, V>): Int {
         return getHeight(node.rightChild) - getHeight(node.leftChild)
     }
-    override fun balanceAfterInsert(insertedNode: AVLNode<K, V>) {
-        val curNode = insertedNode
+    override fun balanceAfterInsert(curNode: AVLNode<K, V>) {
         when (getBalanceFactor(curNode)) {
             -2 -> {
-                curNode.leftChild?.let { if (getBalanceFactor(it) == 1) leftRotate(it, findParent(it)) }
+                curNode.leftChild?.let { if (getBalanceFactor(it) == 1) rotateLeft(it, findParent(it)) }
                 println("rr ${curNode.key}")
-                rightRotate(curNode, findParent(curNode))
+                rotateRight(curNode, findParent(curNode))
                 println("rr done ${curNode.height}")
             }
             2 -> {
-                curNode.rightChild?.let { if (getBalanceFactor(it) == -1) rightRotate(it, findParent(it)) }
-                leftRotate(curNode, findParent(curNode))
+                curNode.rightChild?.let { if (getBalanceFactor(it) == -1) rotateRight(it, findParent(it)) }
+                rotateLeft(curNode, findParent(curNode))
             }
             else -> updateHeight(curNode)
         }
@@ -51,35 +50,23 @@ class AVLTree<K : Comparable<K>, V>: balancedTree<K, V, AVLNode<K, V>>() {
     override fun balanceAfterDelete(curNode: AVLNode<K, V>) {
         TODO("Not yet implemented")
     }
-    private fun swapNodes(node: AVLNode<K, V>, parentNode: AVLNode<K, V>?, nodeToSwap: AVLNode<K, V>?) {
-        when (parentNode) {
-            null -> {
-                if (root == node) root = nodeToSwap
-                //else throw IllegalArgumentException("Node's parent cannot be null if it isn't a root")
-            }
-            else -> {
-                if (parentNode.rightChild == node) parentNode.rightChild = nodeToSwap
-                else if (parentNode.leftChild == node) parentNode.leftChild = nodeToSwap
-            }
-        }
-    }
-    private fun rightRotate (node: AVLNode<K, V>, parentNode:  AVLNode<K, V>?) {
-        val tempNode = node.leftChild ?: throw IllegalArgumentException("Node must have left child for right rotation")
-        node.leftChild = tempNode.rightChild
-        tempNode.rightChild = node
-        swapNodes(node, parentNode, tempNode)
-        println("n: ${node.key}")
-        println("tn: ${tempNode.key}")
+    override fun rotateRight (node: AVLNode<K, V>, parentNode:  AVLNode<K, V>?) {
+        super.rotateRight(node, parentNode)
+//        val tempNode = node.leftChild ?: throw IllegalArgumentException("Node must have left child for right rotation")
+//        node.leftChild = tempNode.rightChild
+//        tempNode.rightChild = node
+//        swapNodes(node, parentNode, tempNode)
         updateHeight(node)
-        updateHeight(tempNode)
+        //updateHeight(tempNode)
     }
-    private fun leftRotate (node: AVLNode<K, V>, parentNode:  AVLNode<K, V>?) {
-        val tempNode = node.rightChild ?: throw IllegalArgumentException("Node must have right child for left rotation")
-        node.rightChild = tempNode.leftChild
-        tempNode.leftChild = node
-        swapNodes(node, parentNode,tempNode)
+    override fun rotateLeft (node: AVLNode<K, V>, parentNode:  AVLNode<K, V>?) {
+        super.rotateLeft(node, parentNode)
+//        val tempNode = node.rightChild ?: throw IllegalArgumentException("Node must have right child for left rotation")
+//        node.rightChild = tempNode.leftChild
+//        tempNode.leftChild = node
+//        swapNodes(node, parentNode,tempNode)
         updateHeight(node)
-        updateHeight(tempNode)
+        //updateHeight(tempNode)
     }
     private fun findParent(node: AVLNode<K, V>): AVLNode<K, V>? { // вродь работает
         var curNode = root

--- a/src/main/kotlin/abstractions/abstraction.kt
+++ b/src/main/kotlin/abstractions/abstraction.kt
@@ -1,5 +1,7 @@
 package abstractions
 
+import AVL.AVLNode
+
 abstract class abstractNode<K: Comparable<K>, V, someNode: abstractNode<K, V, someNode>>(var key:K, var value: V) {
     var leftChild: someNode? = null
     var rightChild: someNode? = null
@@ -114,17 +116,31 @@ abstract class abstractTree<K: Comparable<K>, V, someNode: abstractNode<K, V, so
 }
 
 abstract class balancedTree<K: Comparable<K>, V, someNode: abstractNode<K, V, someNode>>: abstractTree<K, V, someNode>() {
-    protected fun rotateLeft(node: someNode) {
-
+    protected abstract fun balanceAfterInsert(curNode: someNode)
+    protected abstract fun balanceAfterDelete(curNode: someNode)
+    protected open fun rotateRight (node: someNode, parentNode:  someNode?) {
+        val tempNode = node.leftChild ?: throw IllegalArgumentException("Node must have left child for right rotation")
+        node.leftChild = tempNode.rightChild
+        tempNode.rightChild = node
+        swapNodes(node, parentNode, tempNode)
     }
-    protected fun rotateRight(node: someNode) {
-
+    protected open fun rotateLeft (node: someNode, parentNode:  someNode?) {
+        val tempNode = node.rightChild ?: throw IllegalArgumentException("Node must have right child for left rotation")
+        node.rightChild = tempNode.leftChild
+        tempNode.leftChild = node
+        swapNodes(node, parentNode,tempNode)
     }
-    protected open fun balanceAfterInsert(insertedNode: someNode) {
-        return
-    }
-    protected open fun balanceAfterDelete(deletedNode: someNode) {
-        return
+    private fun swapNodes(node: someNode, parentNode: someNode?, nodeToSwap: someNode?) {
+        when (parentNode) {
+            null -> {
+                if (root == node) root = nodeToSwap
+                //else throw IllegalArgumentException("Node's parent cannot be null if it isn't a root")
+            }
+            else -> {
+                if (parentNode.rightChild == node) parentNode.rightChild = nodeToSwap
+                else if (parentNode.leftChild == node) parentNode.leftChild = nodeToSwap
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/abstractions/abstraction.kt
+++ b/src/main/kotlin/abstractions/abstraction.kt
@@ -1,7 +1,5 @@
 package abstractions
 
-import AVL.AVLNode
-
 abstract class abstractNode<K: Comparable<K>, V, someNode: abstractNode<K, V, someNode>>(var key:K, var value: V) {
     var leftChild: someNode? = null
     var rightChild: someNode? = null


### PR DESCRIPTION
implement rotations in balancedTree so that these methods can be used by both AVL and RB trees. override these method in AVL Tree. Also very "drafty" in AVLTree.kt